### PR TITLE
Fact 2165 fix court address serialisation

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,1 +1,2 @@
 lombok.addLombokGeneratedAnnotation = true
+lombok.jacksonized.jacksonVersion += 3

--- a/src/integrationTest/java/uk/gov/hmcts/reform/fact/data/api/controllers/CourtAddressControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/fact/data/api/controllers/CourtAddressControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.qameta.allure.Feature;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -18,6 +19,7 @@ import uk.gov.hmcts.reform.fact.data.api.services.CourtAddressService;
 import java.util.List;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -137,6 +139,26 @@ class CourtAddressControllerTest {
                             .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.addressLine1").value(ADDRESS_LINE_1));
+    }
+
+    @Test
+    @DisplayName("POST /courts/{courtId}/v1/address creates address successfully (with aols)")
+    void createAddressReturnsCreatedWithAol() throws Exception {
+        CourtAddress request = buildAddress();
+        request.setAreasOfLaw(List.of(UUID.randomUUID(), UUID.randomUUID()));
+        request.setId(UUID.randomUUID());
+
+        ArgumentCaptor<CourtAddress> captor = ArgumentCaptor.forClass(CourtAddress.class);
+        when(courtAddressService.createAddress(any(UUID.class), captor.capture()))
+            .thenReturn(buildAddress());
+
+        mockMvc.perform(post(ADDRESSES_V1_PATH, courtId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.addressLine1").value(ADDRESS_LINE_1));
+
+        assertThat(captor.getValue().getAreasOfLaw()).isNotNull().containsAll(request.getAreasOfLaw());
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/entities/CourtAddress.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/entities/CourtAddress.java
@@ -33,6 +33,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 import uk.gov.hmcts.reform.fact.data.api.entities.validation.ValidationConstants;
@@ -42,6 +43,7 @@ import uk.gov.hmcts.reform.fact.data.api.controllers.CourtController.CourtDetail
 @Data
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
+@Jacksonized
 @Builder
 @Entity
 @EntityListeners(AuditableCourtEntityListener.class)

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/os/OsDpa.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/os/OsDpa.java
@@ -29,6 +29,9 @@ public class OsDpa {
     @JsonProperty("BUILDING_NUMBER")
     private String buildingNumber;
 
+    @JsonProperty("BUILDING_NAME")
+    private String buildingName;
+
     @JsonProperty("THOROUGHFARE_NAME")
     private String thoroughfareName;
 


### PR DESCRIPTION
### JIRA link ###

FACT-2165

### Change description ###

Fixes a serialisation issue with UUID list params in the CourtAddress entity.
Adds BUILDING_NAME to the osdata response object 

**Does this PR require manual testing?** (check one with "x")

```
[ ] Yes
[x] No
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
