### PR TITLE
Adjust the stable postcode

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/search/SearchCourtControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/search/SearchCourtControllerFunctionalTest.java
@@ -43,7 +43,7 @@ public final class SearchCourtControllerFunctionalTest {
         .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
         .build();
     private static final String regionId = TestDataHelper.fetchFirstRegionId(http);
-    private static final String STABLE_ENGLAND_POSTCODE = "SW1A 1AA";
+    private static final String STABLE_ENGLAND_POSTCODE = "SW1A 0AA";
     private static final String TEST_COURT_PREFIX = "Test Court";
 
     @Test


### PR DESCRIPTION
### JIRA link ###

FACT-2612

### Change description ###

Update the stable postcode to a different Westminster address (from Buckingham Palace to House of Commons) as the O|S DPA address data for SW1A 1 has started to return an unknown/undocumented custodian code.

**Does this PR require manual testing?** (check one with "x")

```
[ ] Yes
[x No
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
