### PR TITLE
Add unique constraint and determinism to court slug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,7 @@ dependencies {
   implementation group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '12.7.0'
 
   implementation group: 'com.azure.spring', name: 'spring-cloud-azure-starter-storage-blob', version: '7.3.0'
-
+  implementation group: 'com.azure', name: 'azure-storage-blob', version: '12.26.0'
 
   implementation group: 'tools.jackson.datatype', name: 'jackson-datatype-hibernate7'
 

--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,6 @@ dependencies {
   implementation group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '12.7.0'
 
   implementation group: 'com.azure.spring', name: 'spring-cloud-azure-starter-storage-blob', version: '7.3.0'
-  implementation group: 'com.azure', name: 'azure-storage-blob', version: '12.26.0'
 
   implementation group: 'tools.jackson.datatype', name: 'jackson-datatype-hibernate7'
 

--- a/build.gradle
+++ b/build.gradle
@@ -195,6 +195,7 @@ dependencies {
 
   implementation group: 'com.azure.spring', name: 'spring-cloud-azure-starter-storage-blob', version: '7.3.0'
 
+
   implementation group: 'tools.jackson.datatype', name: 'jackson-datatype-hibernate7'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'

--- a/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/AuthFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/AuthFunctionalTest.java
@@ -175,6 +175,7 @@ public class AuthFunctionalTest {
             "/courts/" + courtId + "/v1",
             "/courts/" + courtId + ".json",
             "/courts/slug/" + CourtService.toSlugFormat(testingCourt.getName()) + "/v1",
+            "/courts/slug/" + CourtService.toSlugFormat(testingCourt.getName()) + "/entity/v1",
             "/courts/all/v1",
             "/courts/all.json",
             "/courts/v1?pageNumber=0&pageSize=10&includeClosed=true"

--- a/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/AuthFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/AuthFunctionalTest.java
@@ -28,6 +28,7 @@ import uk.gov.hmcts.reform.fact.data.api.entities.types.Page;
 import uk.gov.hmcts.reform.fact.data.api.entities.types.UserRole;
 import uk.gov.hmcts.reform.fact.data.api.models.AreaOfLawSelectionDto;
 import uk.gov.hmcts.reform.fact.data.api.models.CourtLocalAuthorityDto;
+import uk.gov.hmcts.reform.fact.data.api.services.CourtService;
 import uk.gov.hmcts.reform.fact.functional.helpers.TestDataHelper;
 import uk.gov.hmcts.reform.fact.functional.http.HttpClient;
 
@@ -74,18 +75,13 @@ public class AuthFunctionalTest {
 
     private static UUID createCourtAsAdmin(String name) {
         Court court = new Court();
-        court.setName(name + " " + buildAlphabeticSuffix());
+        court.setName(TestDataHelper.appendRandomSuffixToCourtName(name));
         court.setRegionId(UUID.fromString(getRegionId()));
         court.setOpen(Boolean.FALSE);
         court.setIsServiceCentre(true);
         Response createResponse = http.doPost("/courts/v1", court, adminToken);
         assertThat(createResponse.statusCode()).isEqualTo(201);
         return UUID.fromString(createResponse.jsonPath().getString("id"));
-    }
-
-    private static String buildAlphabeticSuffix() {
-        final String lettersOnly = UUID.randomUUID().toString().replaceAll("[^A-Za-z]", "a");
-        return lettersOnly.substring(0, 8);
     }
 
     private static void assertViewerAllowed(Response adminResponse, Response viewerResponse, String endpoint) {
@@ -159,40 +155,47 @@ public class AuthFunctionalTest {
     @Test
     @DisplayName("Court controller endpoints enforce admin-only writes")
     void courtControllerAuth() {
-        UUID courtId = createCourtAsAdmin("Test Court Auth Core");
-        Court updateCourt = new Court();
-        updateCourt.setName("Test Court Auth Updated");
-        updateCourt.setOpen(Boolean.FALSE);
-        updateCourt.setRegionId(UUID.fromString(getRegionId()));
-        updateCourt.setIsServiceCentre(true);
+
+        Court testingCourt = new Court();
+        testingCourt.setName(TestDataHelper.appendRandomSuffixToCourtName("Test Court Auth"));
+        testingCourt.setOpen(Boolean.FALSE);
+        testingCourt.setRegionId(UUID.fromString(getRegionId()));
+        testingCourt.setIsServiceCentre(true);
+
+        // initially test that only the admin can create the court
+        Response createViewer = http.doPost("/courts/v1", testingCourt, viewerToken);
+        Response createAdmin = http.doPost("/courts/v1", testingCourt, adminToken);
+        assertViewerForbidden(createViewer, "/courts/v1 [POST]");
+        assertThat(createAdmin.statusCode()).isEqualTo(201);
+
+        // retrieve the created court's ID
+        UUID courtId = createAdmin.as(Court.class).getCourtId();
 
         String[] readEndpoints = new String[]{
             "/courts/" + courtId + "/v1",
             "/courts/" + courtId + ".json",
-            "/courts/slug/" + "test-court-auth-updated" + "/v1",
+            "/courts/slug/" + CourtService.toSlugFormat(testingCourt.getName()) + "/v1",
             "/courts/all/v1",
             "/courts/all.json",
             "/courts/v1?pageNumber=0&pageSize=10&includeClosed=true"
         };
 
+        // ensure that both roles can access read endpoints
         for (String endpoint : readEndpoints) {
             Response admin = http.doGet(endpoint, adminToken);
             Response viewer = http.doGet(endpoint, viewerToken);
             assertViewerAllowed(admin, viewer, endpoint);
         }
 
-        Response createAdmin = http.doPost("/courts/v1", updateCourt, adminToken);
-        Response createViewer = http.doPost("/courts/v1", updateCourt, viewerToken);
-        assertThat(createAdmin.statusCode()).isEqualTo(201);
-        assertViewerForbidden(createViewer, "/courts/v1 [POST]");
-
-        Response updateAdmin = http.doPut("/courts/" + courtId + "/v1", updateCourt, adminToken);
-        Response updateViewer = http.doPut("/courts/" + courtId + "/v1", updateCourt, viewerToken);
-        assertThat(updateAdmin.statusCode()).isEqualTo(200);
+        // ensure that only admin can update the court
+        testingCourt.setName(TestDataHelper.appendRandomSuffixToCourtName("Test Court Auth Updated"));
+        Response updateViewer = http.doPut("/courts/" + courtId + "/v1", testingCourt, viewerToken);
+        Response updateAdmin = http.doPut("/courts/" + courtId + "/v1", testingCourt, adminToken);
         assertViewerForbidden(updateViewer, "/courts/{courtId}/v1 [PUT]");
+        assertThat(updateAdmin.statusCode()).isEqualTo(200);
 
         assertUnauthenticated(http.doGet("/courts/v1", ""), "/courts/v1 [GET]");
-        assertUnauthenticated(http.doPost("/courts/v1", updateCourt, ""), "/courts/v1 [POST]");
+        assertUnauthenticated(http.doPost("/courts/v1", testingCourt, ""), "/courts/v1 [POST]");
     }
 
     @Test

--- a/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/CourtControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/CourtControllerFunctionalTest.java
@@ -423,6 +423,43 @@ public final class CourtControllerFunctionalTest {
     }
 
     @Test
+    @DisplayName("GET /courts/slug/{courtSlug}/entity/v1 returns court entity")
+    void shouldReturnCourtEntityViaSlugPath() throws Exception {
+        final UUID courtId = TestDataHelper.createCourt(http, "Test Court Slug Entity Path");
+
+        final Response byIdResponse = http.doGet("/courts/" + courtId + "/v1");
+        final CourtDetails courtFromIdPath = mapper.readValue(byIdResponse.getBody().asString(), CourtDetails.class);
+
+        final Response response = http.doGet("/courts/slug/" + courtFromIdPath.getSlug() + "/entity/v1");
+
+        AssertionHelper.assertStatus(response, OK);
+
+        final Court fetchedCourt = mapper.readValue(
+            response.getBody().asString(),
+            Court.class
+        );
+
+        assertThat(fetchedCourt.getId())
+            .as("Court ID should match the created court")
+            .isEqualTo(courtId);
+        assertThat(fetchedCourt.getSlug())
+            .as("Court slug should match the created court")
+            .isEqualTo(courtFromIdPath.getSlug());
+    }
+
+    @Test
+    @DisplayName("GET /courts/slug/{courtSlug}/entity/v1 returns 404 for unknown slug")
+    void shouldFailToRetrieveNonExistentCourtEntityBySlug() {
+        final Response response = http.doGet("/courts/slug/non-existent-court/entity/v1");
+
+        AssertionHelper.assertStatus(response, NOT_FOUND);
+
+        assertThat(response.jsonPath().getString("message"))
+            .as("Error message should indicate court entity not found by slug")
+            .contains("Court not found, slug: non-existent-court");
+    }
+
+    @Test
     @DisplayName("POST /courts/v1/link links CaTH courts to FaCT successfully")
     void shouldLinkCaTHCourtsToFaCTSuccessfully() throws Exception {
         final UUID courtId = TestDataHelper.createCourt(http, "Test Court For CaTH Linking", false);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/CourtControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/CourtControllerFunctionalTest.java
@@ -41,7 +41,7 @@ public final class CourtControllerFunctionalTest {
     @DisplayName("POST /courts/v1 creates court and verifies persistence")
     void shouldCreateCourtWithValidPayload() throws Exception {
         final Court court = new Court();
-        court.setName("Test Court Create Valid");
+        court.setName(TestDataHelper.appendRandomSuffixToCourtName("Test Court Create Valid"));
         court.setRegionId(UUID.fromString(regionId));
         court.setIsServiceCentre(true);
         court.setOpen(false);
@@ -62,7 +62,7 @@ public final class CourtControllerFunctionalTest {
         final CourtDetails fetchedCourt = mapper.readValue(getResponse.getBody().asString(), CourtDetails.class);
         assertThat(fetchedCourt.getName())
             .as("Court name should match")
-            .isEqualTo("Test Court Create Valid");
+            .startsWith("Test Court Create Valid");
         assertThat(fetchedCourt.getRegionId())
             .as("Court region ID should match")
             .isEqualTo(UUID.fromString(regionId));
@@ -75,7 +75,7 @@ public final class CourtControllerFunctionalTest {
     @DisplayName("POST /courts/v1 fails with non-existent region ID")
     void shouldFailWithNonExistentRegionId() throws Exception {
         final Court court = new Court();
-        court.setName("Test Court Invalid Region");
+        court.setName(TestDataHelper.appendRandomSuffixToCourtName("Test Court Invalid Region"));
         court.setRegionId(UUID.randomUUID());
         court.setIsServiceCentre(true);
         court.setOpen(false);
@@ -127,7 +127,7 @@ public final class CourtControllerFunctionalTest {
         final ZonedDateTime timestampBeforeUpdate = AssertionHelper.getCourtLastUpdatedAt(http, courtId);
 
         final Court updatedCourt = new Court();
-        updatedCourt.setName("Test Court Updated");
+        updatedCourt.setName(TestDataHelper.appendRandomSuffixToCourtName("Test Court Updated"));
         updatedCourt.setRegionId(UUID.fromString(regionId));
         updatedCourt.setIsServiceCentre(true);
         updatedCourt.setOpen(false);
@@ -143,7 +143,7 @@ public final class CourtControllerFunctionalTest {
         final CourtDetails fetchedCourt = mapper.readValue(getResponse.getBody().asString(), CourtDetails.class);
         assertThat(fetchedCourt.getName())
             .as("Court name should be updated")
-            .isEqualTo("Test Court Updated");
+            .startsWith("Test Court Updated");
         assertThat(fetchedCourt.getIsServiceCentre())
             .as("Court should remain a service centre")
             .isTrue();
@@ -160,7 +160,7 @@ public final class CourtControllerFunctionalTest {
         final UUID nonExistentCourtId = UUID.randomUUID();
 
         final Court updatedCourt = new Court();
-        updatedCourt.setName("Test Court Non-Existent court ID");
+        updatedCourt.setName(TestDataHelper.appendRandomSuffixToCourtName("Test Court Non-Existent court ID"));
         updatedCourt.setRegionId(UUID.fromString(regionId));
         updatedCourt.setIsServiceCentre(true);
         updatedCourt.setOpen(false);
@@ -180,7 +180,7 @@ public final class CourtControllerFunctionalTest {
         final UUID courtId = TestDataHelper.createCourt(http, "Test Court Update Non-Existent Region ID", false);
 
         final Court updatedCourt = new Court();
-        updatedCourt.setName("Test Court Non-Existent Region ID Updated");
+        updatedCourt.setName(TestDataHelper.appendRandomSuffixToCourtName("Test Court Non-Existent Region ID Updated"));
         updatedCourt.setRegionId(UUID.randomUUID());
         updatedCourt.setIsServiceCentre(true);
         updatedCourt.setOpen(false);
@@ -228,7 +228,7 @@ public final class CourtControllerFunctionalTest {
         final UUID courtId = TestDataHelper.createCourt(http, "Test Court Open", false);
 
         final Court updatedCourt = new Court();
-        updatedCourt.setName("Test Court Open");
+        updatedCourt.setName(TestDataHelper.appendRandomSuffixToCourtName("Test Court Open"));
         updatedCourt.setRegionId(UUID.fromString(regionId));
         updatedCourt.setIsServiceCentre(true);
         updatedCourt.setOpen(true);
@@ -300,7 +300,7 @@ public final class CourtControllerFunctionalTest {
             .isPresent();
         assertThat(matchingCourt.orElseThrow().path("name").asString())
             .as("Court name should match the created court")
-            .isEqualTo("Test Court All Details");
+            .startsWith("Test Court All Details");
     }
 
     @Test
@@ -326,7 +326,7 @@ public final class CourtControllerFunctionalTest {
             .isPresent();
         assertThat(matchingCourt.orElseThrow().path("name").asString())
             .as("Court name should match the created court")
-            .isEqualTo("Test Court All Json Path");
+            .startsWith("Test Court All Json Path");
     }
 
     @Test
@@ -353,7 +353,7 @@ public final class CourtControllerFunctionalTest {
             .isEqualTo(courtId);
         assertThat(fetchedCourt.getName())
             .as("Court name should match the created court")
-            .isEqualTo("Test Court Single Json Path");
+            .startsWith("Test Court Single Json Path");
     }
 
     @Test

--- a/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/CourtOpeningHoursControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/CourtOpeningHoursControllerFunctionalTest.java
@@ -58,7 +58,7 @@ public final class CourtOpeningHoursControllerFunctionalTest {
         courtId = UUID.randomUUID();
         court = new Court();
         court.setId(courtId);
-        court.setName("Test Court");
+        court.setName(TestDataHelper.appendRandomSuffixToCourtName("Test Court"));
 
         openingTimesDetails = List.of(
             new OpeningTimesDetail(

--- a/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/CourtPhotoControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/CourtPhotoControllerFunctionalTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.fact.functional.controllers;
 
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.DateTimeFeature;
 import tools.jackson.databind.json.JsonMapper;
@@ -29,6 +30,11 @@ import static org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE;
 
 @Feature("Court Photo Controller")
 @DisplayName("Court Photo Controller")
+@DisabledIfEnvironmentVariable(
+    named = "SKIP_TESTS_PHOTO",
+    matches = "true",
+    disabledReason = "Photo tests are disabled"
+)
 public final class CourtPhotoControllerFunctionalTest {
 
     private static final HttpClient http = new HttpClient();

--- a/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/search/SearchCourtControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/search/SearchCourtControllerFunctionalTest.java
@@ -66,7 +66,7 @@ public final class SearchCourtControllerFunctionalTest {
         assertThat(courts)
             .as("Expected to find the created court '%s' in search results", courtName)
             .extracting(Court::getName)
-            .contains(courtName);
+            .anyMatch(name -> name.startsWith(courtName));
     }
 
     @Test
@@ -93,7 +93,7 @@ public final class SearchCourtControllerFunctionalTest {
             .as("All returned courts should start with 'T'")
             .allMatch(name -> name.toUpperCase().startsWith("T"))
             .as("Expected to find the created court '%s' in prefix results", courtName)
-            .contains(courtName);
+            .anyMatch(name -> name.startsWith(courtName));
     }
 
     @Test
@@ -650,7 +650,7 @@ public final class SearchCourtControllerFunctionalTest {
         final UUID courtId = TestDataHelper.createCourt(http, courtName);
 
         final Court courtToUpdate = new Court();
-        courtToUpdate.setName(courtName);
+        courtToUpdate.setName(TestDataHelper.appendRandomSuffixToCourtName(courtName));
         courtToUpdate.setRegionId(UUID.fromString(regionId));
         courtToUpdate.setIsServiceCentre(true);
         courtToUpdate.setOpen(true);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/helpers/TestDataHelper.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/helpers/TestDataHelper.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.fact.functional.http.HttpClient;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.security.SecureRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.CREATED;
@@ -30,6 +31,7 @@ public final class TestDataHelper {
     private static final ObjectMapper mapper = JsonMapper.builder()
         .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
         .build();
+    private static final SecureRandom random = new SecureRandom();
 
     private TestDataHelper() {
         // Utility class
@@ -83,6 +85,30 @@ public final class TestDataHelper {
     }
 
     /**
+     * Appends a random 6-character lowercase suffix to the provided court name.
+     *
+     * @param courtName the base court name
+     * @return the court name with random suffix appended
+     */
+    public static String appendRandomSuffixToCourtName(final String courtName) {
+        return courtName + " " + generateRandomLowercaseString(6);
+    }
+
+    /**
+     * Generates a random lowercase alphabetic string (a-z) with the requested length.
+     *
+     * @param length the length of random string
+     * @return random lowercase string
+     */
+    public static String generateRandomLowercaseString(final int length) {
+        final StringBuilder randomString = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            randomString.append((char) ('a' + random.nextInt(26)));
+        }
+        return randomString.toString();
+    }
+
+    /**
      * Creates a test court with the given name.
      *
      * @param http the HTTP client
@@ -103,7 +129,7 @@ public final class TestDataHelper {
      */
     public static UUID createCourt(final HttpClient http, final String courtName, boolean isOpen) {
         final Court court = new Court();
-        court.setName(courtName);
+        court.setName(appendRandomSuffixToCourtName(courtName));
         court.setRegionId(UUID.fromString(fetchFirstRegionId(http)));
         court.setIsServiceCentre(true);
         court.setOpen(isOpen);
@@ -128,7 +154,7 @@ public final class TestDataHelper {
         final HttpClient http, final String courtName, boolean isOpen, final String mrdId, boolean openOnCath) {
 
         final Court court = new Court();
-        court.setName(courtName);
+        court.setName(appendRandomSuffixToCourtName(courtName));
         court.setRegionId(UUID.fromString(fetchFirstRegionId(http)));
         court.setIsServiceCentre(true);
         court.setOpen(isOpen);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/fact/data/api/controllers/CourtControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/fact/data/api/controllers/CourtControllerTest.java
@@ -520,7 +520,7 @@ class CourtControllerTest {
         return CourtDetails.builder()
             .id(id)
             .name(name)
-            .slug(courtService.toSlugFormat(name))
+            .slug(CourtService.toSlugFormat(name))
             .open(Boolean.TRUE)
             .warningNotice("Notice")
             .regionId(REGION_ID)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/fact/data/api/controllers/CourtControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/fact/data/api/controllers/CourtControllerTest.java
@@ -213,6 +213,40 @@ class CourtControllerTest {
     }
 
     @Test
+    @DisplayName("GET /courts/slug/{courtSlug}/entity/v1 returns court entity")
+    void getCourtEntityBySlugReturnsCourt() throws Exception {
+        Court court = buildCourt(COURT_ID);
+
+        when(courtService.getCourtBySlug(COURT_SLUG)).thenReturn(court);
+
+        mockMvc.perform(get("/courts/slug/{courtSlug}/entity/v1", COURT_SLUG))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(COURT_ID.toString()))
+            .andExpect(jsonPath("$.name").value("Test Court"))
+            .andExpect(jsonPath("$.regionId").value(REGION_ID.toString()));
+    }
+
+    @Test
+    @DisplayName("GET /courts/slug/{courtSlug}/entity/v1 returns 404 when court missing")
+    void getCourtEntityBySlugReturnsNotFound() throws Exception {
+        when(courtService.getCourtBySlug(UNKNOWN_COURT_SLUG))
+            .thenThrow(new NotFoundException("Court not found"));
+
+        mockMvc.perform(get("/courts/slug/{courtSlug}/entity/v1", UNKNOWN_COURT_SLUG))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /courts/slug/{courtSlug}/entity/v1 returns 400 for invalid slug")
+    void getCourtEntityBySlugReturnsBadRequestForInvalidSlug() throws Exception {
+        mockMvc.perform(get("/courts/slug/{courtSlug}/entity/v1", "INVALID SLUG"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString(
+                ValidationConstants.COURT_SLUG_REGEX_MESSAGE
+            )));
+    }
+
+    @Test
     @DisplayName("GET /courts/v1 returns paginated list")
     void getFilteredAndPaginatedCourtsReturnsResults() throws Exception {
         Court court = buildCourt(COURT_ID);

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/controllers/CourtController.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/controllers/CourtController.java
@@ -109,6 +109,24 @@ public class CourtController {
         );
     }
 
+    @GetMapping(value = "/slug/{courtSlug}/entity/v1")
+    @JsonView(CourtDetailsView.class)
+    @Operation(
+        summary = "Get court entity by slug",
+        description = "Fetch detailed court information for a given court slug."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved court details"),
+        @ApiResponse(responseCode = "400", description = "Invalid court slug supplied"),
+        @ApiResponse(responseCode = "404", description = "Court not found")
+    })
+    public ResponseEntity<Court> getCourtEntityBySlug(
+        @Parameter(description = "Slug of the court", required = true)
+        @ValidCourtSlug
+        @PathVariable String courtSlug) {
+        return ResponseEntity.ok(courtService.getCourtBySlug(courtSlug));
+    }
+
     @GetMapping(value = {"/all/v1", "/all.json"})
     @JsonView(CourtDetailsView.class)
     @Operation(

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/entities/AbstractCourtEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/entities/AbstractCourtEntity.java
@@ -55,6 +55,7 @@ public abstract class AbstractCourtEntity {
 
     @Schema(description = "The Court 'slug'")
     @ValidCourtSlug
+    @Column(unique = true)
     private String slug;
 
     @Schema(description = "The open status of the Court")

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/repositories/CourtRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/repositories/CourtRepository.java
@@ -47,14 +47,6 @@ public interface CourtRepository extends JpaRepository<Court, UUID> {
     );
 
     /**
-     * Checks whether a court slug already exists.
-     *
-     * @param slug the slug to check
-     * @return true if the slug exists
-     */
-    boolean existsBySlug(String slug);
-
-    /**
      * Finds courts whose names start with the provided prefix.
      *
      * @param namePrefix the name prefix

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/repositories/CourtRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/repositories/CourtRepository.java
@@ -122,4 +122,12 @@ public interface CourtRepository extends JpaRepository<Court, UUID> {
      * @return the NameAndSlug object
      */
     Optional<NameAndSlug> findNameAndSlugById(UUID id);
+
+    /**
+     * Find a court instance using the court slug.
+     *
+     * @param slug the slug
+     * @return an {@link Optional} {@link Court} instance if found, otherwise an empty {@link Optional}
+     */
+    Optional<Court> findBySlug(String slug);
 }

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/CourtService.java
@@ -139,16 +139,11 @@ public class CourtService {
         existingCourt.setRegionId(foundRegion.getId());
         existingCourt.setWarningNotice(court.getWarningNotice());
 
-        try {
-            log.info("Updating court: {}", courtId);
-            Court updatedCourt = courtRepository.save(existingCourt);
-            handleCathNotification(previousOpenStatus, updatedCourt);
+        Court updatedCourt = courtRepository.save(existingCourt);
 
-            return updatedCourt;
-        } catch (Exception e) {
-            throw e;
-        }
+        handleCathNotification(previousOpenStatus, updatedCourt);
 
+        return updatedCourt;
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/CourtService.java
@@ -58,6 +58,18 @@ public class CourtService {
     }
 
     /**
+     * Get a court by its slug.
+     *
+     * @param courtSlug the court slug
+     * @return {@link NotFoundException} if the court is not found.
+     */
+    public Court getCourtBySlug(final String courtSlug) {
+        return courtRepository.findBySlug(courtSlug)
+            .orElseThrow(() -> new NotFoundException("Court not found, slug: " + courtSlug));
+    }
+
+
+    /**
      * Get multiple courts by their IDs.
      *
      * @param courtIds List of court IDs to retrieve.

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/CourtService.java
@@ -108,7 +108,7 @@ public class CourtService {
     public Court createCourt(Court court) {
         Region foundRegion = regionService.getRegionById(court.getRegionId());
         court.setRegionId(foundRegion.getId());
-        court.setSlug(toUniqueSlug(court.getName()));
+        court.setSlug(toSlugFormat(court.getName()));
 
         // A court is closed on creation until an address is added.
         court.setOpen(false);
@@ -132,18 +132,23 @@ public class CourtService {
 
         if (!existingCourt.getName().equalsIgnoreCase(court.getName())) {
             existingCourt.setName(court.getName());
-            existingCourt.setSlug(toUniqueSlug(court.getName()));
+            existingCourt.setSlug(toSlugFormat(court.getName()));
         }
 
         existingCourt.setOpen(court.getOpen());
         existingCourt.setRegionId(foundRegion.getId());
         existingCourt.setWarningNotice(court.getWarningNotice());
 
-        Court updatedCourt = courtRepository.save(existingCourt);
+        try {
+            log.info("Updating court: {}", courtId);
+            Court updatedCourt = courtRepository.save(existingCourt);
+            handleCathNotification(previousOpenStatus, updatedCourt);
 
-        handleCathNotification(previousOpenStatus, updatedCourt);
+            return updatedCourt;
+        } catch (Exception e) {
+            throw e;
+        }
 
-        return updatedCourt;
     }
 
     /**
@@ -274,30 +279,11 @@ public class CourtService {
      * @param name the court name
      * @return the slug representation of the name
      */
-    public String toSlugFormat(String name) {
+    public static String toSlugFormat(String name) {
         return name.toLowerCase()
             .replaceAll("[^a-z\\s-]", "")
             .replaceAll("[\\s-]+", "-")
             .replaceAll("(^-)|(-$)", "");
-    }
-
-    /**
-     * Converts a court name to a unique slug.
-     *
-     * @param name The court name.
-     * @return A unique slug.
-     */
-    private String toUniqueSlug(String name) {
-        String baseSlug = toSlugFormat(name);
-
-        String slug = baseSlug;
-        int counter = 1;
-
-        while (courtRepository.existsBySlug(slug)) {
-            slug = baseSlug + "-" + counter++;
-        }
-
-        return slug;
     }
 
     /**

--- a/src/main/resources/db/migration/V1.25__add_unique_constraint_to_court_slug.sql
+++ b/src/main/resources/db/migration/V1.25__add_unique_constraint_to_court_slug.sql
@@ -1,0 +1,2 @@
+ALTER TABLE court
+  ADD CONSTRAINT court_slug_unique UNIQUE (slug);

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/controllers/CourtControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/controllers/CourtControllerTest.java
@@ -134,6 +134,28 @@ class CourtControllerTest {
     }
 
     @Test
+    void getCourtEntityBySlugReturns200() {
+        Court court = createCourt();
+
+        when(courtService.getCourtBySlug(COURT_SLUG)).thenReturn(court);
+
+        ResponseEntity<Court> response = courtController.getCourtEntityBySlug(COURT_SLUG);
+
+        assertThat(response.getStatusCode()).as(RESPONSE_STATUS_MESSAGE).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).as(RESPONSE_BODY_MESSAGE).isEqualTo(court);
+    }
+
+    @Test
+    void getCourtEntityBySlugThrowsNotFoundException() {
+        when(courtService.getCourtBySlug(UNKNOWN_COURT_SLUG))
+            .thenThrow(new NotFoundException("Court not found"));
+
+        assertThrows(NotFoundException.class, () ->
+            courtController.getCourtEntityBySlug(UNKNOWN_COURT_SLUG)
+        );
+    }
+
+    @Test
     void getFilteredAndPaginatedCourtsReturns200() {
         Court court = createCourt();
         Page<Court> courtPage = new PageImpl<>(List.of(court));

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/services/CourtServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/services/CourtServiceTest.java
@@ -97,6 +97,50 @@ class CourtServiceTest {
     }
 
     @Test
+    void getCourtBySlugReturnsCourtWhenFound() {
+        String courtSlug = "test-court";
+        Court court = new Court();
+        court.setSlug(courtSlug);
+        court.setName("Test Court");
+
+        when(courtRepository.findBySlug(courtSlug)).thenReturn(Optional.of(court));
+
+        Court result = courtService.getCourtBySlug(courtSlug);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getSlug()).isEqualTo(courtSlug);
+        assertThat(result.getName()).isEqualTo("Test Court");
+    }
+
+    @Test
+    void getCourtBySlugThrowsNotFoundExceptionWhenCourtDoesNotExist() {
+        String courtSlug = "missing-court";
+
+        when(courtRepository.findBySlug(courtSlug)).thenReturn(Optional.empty());
+
+        NotFoundException exception = assertThrows(
+            NotFoundException.class, () ->
+                courtService.getCourtBySlug(courtSlug)
+        );
+
+        assertThat(exception.getMessage()).isEqualTo("Court not found, slug: " + courtSlug);
+    }
+
+    @Test
+    void getCourtBySlugThrowsNotFoundExceptionWhenSlugIsBlank() {
+        String courtSlug = "   ";
+
+        when(courtRepository.findBySlug(courtSlug)).thenReturn(Optional.empty());
+
+        NotFoundException exception = assertThrows(
+            NotFoundException.class, () ->
+                courtService.getCourtBySlug(courtSlug)
+        );
+
+        assertThat(exception.getMessage()).isEqualTo("Court not found, slug: " + courtSlug);
+    }
+
+    @Test
     void getAllCourtsByIdsReturnsMatchingCourts() {
         UUID courtId1 = UUID.randomUUID();
         UUID courtId2 = UUID.randomUUID();

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/services/CourtServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/services/CourtServiceTest.java
@@ -314,7 +314,6 @@ class CourtServiceTest {
         input.setRegionId(regionId);
 
         when(regionService.getRegionById(regionId)).thenReturn(region);
-        when(courtRepository.existsBySlug(anyString())).thenReturn(false);
         when(courtRepository.save(any(Court.class))).thenAnswer(inv -> inv.getArgument(0));
 
         Court saved = courtService.createCourt(input);
@@ -323,25 +322,6 @@ class CourtServiceTest {
         assertThat(saved.getRegionId()).isEqualTo(region.getId());
         assertThat(saved.getSlug()).isEqualTo("my-test-court");
         verify(courtRepository).save(saved);
-    }
-
-    @Test
-    void createCourtShouldGenerateUniqueSlugWhenDuplicateExists() {
-        UUID regionId = UUID.randomUUID();
-        Region region = new Region();
-        region.setId(regionId);
-        Court input = new Court();
-        input.setName("Duplicate Court");
-        input.setRegionId(regionId);
-
-        when(regionService.getRegionById(regionId)).thenReturn(region);
-        when(courtRepository.existsBySlug("duplicate-court")).thenReturn(true);
-        when(courtRepository.existsBySlug("duplicate-court-1")).thenReturn(false);
-        when(courtRepository.save(any(Court.class))).thenAnswer(inv -> inv.getArgument(0));
-
-        Court result = courtService.createCourt(input);
-
-        assertThat(result.getSlug()).isEqualTo("duplicate-court-1");
     }
 
     @Test
@@ -363,7 +343,6 @@ class CourtServiceTest {
 
         when(courtRepository.findById(courtId)).thenReturn(Optional.of(existing));
         when(regionService.getRegionById(regionId)).thenReturn(region);
-        when(courtRepository.existsBySlug("new-name")).thenReturn(false);
         when(courtRepository.save(any(Court.class))).thenAnswer(inv -> inv.getArgument(0));
 
         Court result = courtService.updateCourt(courtId, updated);
@@ -397,7 +376,6 @@ class CourtServiceTest {
         Court result = courtService.updateCourt(courtId, updated);
 
         assertThat(result.getSlug()).isEqualTo("same-name");
-        verify(courtRepository, never()).existsBySlug(anyString());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link ###

FACT-2164

### Change description ###

Add a unique constraint to the court slug column and remove code that fixes collisions as we will now require that court names are unique (once normalised)

Functional tests have been updated to reflect the need to use unique names for test courts. problem tests have been refactored to prevent collisions and expectations have been changed to deal with randomness in court names (e.g. `startsWith` tests instead of `equals` tests) 

All non-blobstore functional testing is working locally, and all current functional tests run from the admin and public frontends are passing.

**Does this PR require manual testing?** (check one with "x")

```
[ ] Yes
[x] No
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
