### PR TITLE
FACT-2612

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/TypesControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/fact/functional/controllers/TypesControllerFunctionalTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.fact.functional.http.HttpClient;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
 import static org.springframework.http.HttpStatus.OK;
@@ -99,7 +101,11 @@ public final class TypesControllerFunctionalTest {
         assertThat(response.statusCode()).isEqualTo(OK.value());
         assertThat(response.contentType()).contains("json");
         assertThat(response.jsonPath().getList("$")).isNotEmpty();
-        assertThat(response.jsonPath().getString("[0].name")).isEqualTo("Adur District Council");
+
+        final List<String> localAuthorityNames = response.jsonPath().getList("name");
+        assertThat(localAuthorityNames)
+            .contains("Barnsley Metropolitan Borough Council")
+            .doesNotContain("Adur District Council");
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/controllers/TypesController.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/controllers/TypesController.java
@@ -114,7 +114,7 @@ public class TypesController {
     @GetMapping("/v1/local-authorities")
     @Operation(
         summary = "Get all local authorities",
-        description = "Fetch the complete set of local authorities."
+        description = "Fetch the complete set of parent local authorities."
             + "Returns empty list if no local authorities exist."
     )
     @ApiResponses(value = {

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/repositories/LocalAuthorityTypeRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/repositories/LocalAuthorityTypeRepository.java
@@ -1,18 +1,33 @@
 package uk.gov.hmcts.reform.fact.data.api.repositories;
 
-import org.springframework.data.jpa.repository.Query;
-import uk.gov.hmcts.reform.fact.data.api.entities.LocalAuthorityType;
-
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import uk.gov.hmcts.reform.fact.data.api.entities.LocalAuthorityType;
 
 @Repository
 public interface LocalAuthorityTypeRepository extends JpaRepository<LocalAuthorityType, UUID> {
 
     Optional<LocalAuthorityType> findByNameIgnoreCase(String name);
+
+    /**
+     * Finds all parent local authorities.
+     *
+     * @return parent local authorities
+     */
+    @Query(
+        value = """
+            SELECT id, name, custodian_code, child_custodian_codes
+            FROM local_authority_types
+            WHERE is_parent = TRUE
+            """,
+        nativeQuery = true
+    )
+    List<LocalAuthorityType> findAllParents();
 
     /**
      * Finds the parent or child authority by custodian code.

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/CourtLocalAuthoritiesService.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/CourtLocalAuthoritiesService.java
@@ -173,7 +173,7 @@ public class CourtLocalAuthoritiesService {
      * @return The list of CourtLocalAuthorityDto objects.
      */
     private List<CourtLocalAuthorityDto> buildCourtLocalAuthorityDtoList(UUID courtId, List<AreaOfLawType> areas) {
-        List<LocalAuthorityType> allLocalAuthorities = localAuthorityTypeRepository.findAll()
+        List<LocalAuthorityType> allLocalAuthorities = localAuthorityTypeRepository.findAllParents()
             .stream()
             .sorted(Comparator.comparing(LocalAuthorityType::getName, String.CASE_INSENSITIVE_ORDER))
             .toList();

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/TypesService.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/TypesService.java
@@ -158,6 +158,6 @@ public class TypesService {
      * @return The local authorities.
      */
     public List<LocalAuthorityType> getLocalAuthorities() {
-        return localAuthorityTypeRepository.findAll();
+        return localAuthorityTypeRepository.findAllParents();
     }
 }

--- a/src/main/resources/db/migration/V1.26__create_is_parent_la_types.sql
+++ b/src/main/resources/db/migration/V1.26__create_is_parent_la_types.sql
@@ -1,0 +1,9 @@
+ALTER TABLE local_authority_types
+  ADD COLUMN is_parent BOOLEAN NOT NULL DEFAULT TRUE;
+
+UPDATE local_authority_types lat
+SET is_parent = NOT EXISTS (
+  SELECT 1
+  FROM local_authority_types parent
+  WHERE lat.custodian_code = ANY(parent.child_custodian_codes)
+);

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/services/CourtLocalAuthoritiesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/services/CourtLocalAuthoritiesServiceTest.java
@@ -97,7 +97,7 @@ class CourtLocalAuthoritiesServiceTest {
 
         when(courtService.getCourtById(COURT_ID)).thenReturn(court);
         mockAllowedAreasOfLaw();
-        when(localAuthorityTypeRepository.findAll()).thenReturn(List.of(laTwo, laOne));
+        when(localAuthorityTypeRepository.findAllParents()).thenReturn(List.of(laTwo, laOne));
         when(courtLocalAuthoritiesRepository.findByCourtIdAndAreaOfLawId(COURT_ID, ADOPTION_ID))
             .thenReturn(Optional.of(adoptionAuthorities));
         when(courtLocalAuthoritiesRepository.findByCourtIdAndAreaOfLawId(COURT_ID, CHILDREN_ID))
@@ -115,6 +115,8 @@ class CourtLocalAuthoritiesServiceTest {
         List<LocalAuthoritySelectionDto> childrenAuthorities = childrenResult.getLocalAuthorities();
         assertThat(childrenAuthorities).isNotEmpty();
         assertThat(childrenAuthorities).allMatch(la -> Boolean.FALSE.equals(la.getSelected()));
+        verify(localAuthorityTypeRepository).findAllParents();
+        verify(localAuthorityTypeRepository, never()).findAll();
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/services/TypesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/services/TypesServiceTest.java
@@ -237,7 +237,7 @@ class TypesServiceTest {
 
     @Test
     void getLocalAuthoritiesReturnsLocalAuthoritiesWhenFound() {
-        when(localAuthorityTypeRepository.findAll()).thenReturn(localAuthorityTypes);
+        when(localAuthorityTypeRepository.findAllParents()).thenReturn(localAuthorityTypes);
 
         List<LocalAuthorityType> result = typesService.getLocalAuthorities();
 
@@ -246,9 +246,10 @@ class TypesServiceTest {
 
     @Test
     void getLocalAuthoritiesReturnsEmptyListWhenNoneFound() {
+        when(localAuthorityTypeRepository.findAllParents()).thenReturn(List.of());
+
         List<LocalAuthorityType> result = typesService.getLocalAuthorities();
 
         assertThat(result).isEmpty();
     }
 }
-


### PR DESCRIPTION
• Summary

  - Updated the local authorities type endpoint flow to return only parent local authorities.
  - Added a repository query filtering local_authority_types by is_parent = TRUE.
  - Changed TypesService.getLocalAuthorities() to use the new parent-only repository method.
  - Updated endpoint documentation to describe parent local authorities.
  - Updated unit tests to verify the service uses the parent-only repository call.

  Testing

  - ./gradlew test --tests uk.gov.hmcts.reform.fact.data.api.services.TypesServiceTest --tests
    uk.gov.hmcts.reform.fact.data.api.controllers.TypesControllerTest
