### PR TITLE
Add crude local caching of os postcode lookup data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,9 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security-oauth2-client'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security-oauth2-resource-server'
   implementation group: 'com.azure.spring', name: 'spring-cloud-azure-starter', version: '7.3.0'
+  // cache
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache'
+  implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine'
 
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '3.0.3'
 

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/config/CacheConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/config/CacheConfiguration.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.fact.data.api.config;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Scheduler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+@ConditionalOnProperty(prefix = "testingSupport", name = "enableCache", havingValue = "true")
+@Slf4j
+public class CacheConfiguration {
+
+    public static final String OSDATA_CACHE_NAME = "osdata";
+
+    ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new
+            CaffeineCacheManager();
+        cacheManager.registerCustomCache(OSDATA_CACHE_NAME, buildOsDataCache());
+        return cacheManager;
+    }
+
+    private Cache<Object, Object> buildOsDataCache() {
+        Cache<Object, Object> cache = Caffeine.newBuilder()
+            .initialCapacity(10)
+            .maximumSize(1000)
+            .expireAfterWrite(Duration.ofHours(1))
+            .recordStats()
+            .scheduler(Scheduler.systemScheduler())
+            .build();
+
+        executorService.scheduleWithFixedDelay(() -> log.info("OsData Cache stats: {}", cache.stats()),
+                                               0, 5, TimeUnit.MINUTES);
+
+        return cache;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/OsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/OsService.java
@@ -1,7 +1,10 @@
 package uk.gov.hmcts.reform.fact.data.api.services;
 
 import feign.FeignException;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+
+import uk.gov.hmcts.reform.fact.data.api.config.CacheConfiguration;
 import uk.gov.hmcts.reform.fact.data.api.errorhandling.exceptions.InvalidPostcodeException;
 import uk.gov.hmcts.reform.fact.data.api.errorhandling.exceptions.OsProcessException;
 import uk.gov.hmcts.reform.fact.data.api.os.OsData;
@@ -40,6 +43,7 @@ public class OsService {
      * @return the location data returned from OS plus a mapping to determine the admin
      *     district based on the child and parent custodian codes.
      */
+    @Cacheable(cacheNames = CacheConfiguration.OSDATA_CACHE_NAME, key = "'T-' + #postcode")
     public OsLocationData getOsLonLatDistrictByPartial(String postcode) {
         return getOsLatLonDistrictLookup(
             toOutwardPlusSingleInwardDigit(
@@ -53,6 +57,7 @@ public class OsService {
      * @param postcode the postcode.
      * @return the OsData containing all addresses for the provided postcode.
      */
+    @Cacheable(cacheNames = CacheConfiguration.OSDATA_CACHE_NAME, key = "'F-' + #postcode")
     public OsData getOsAddressByFullPostcode(String postcode) {
         return getOsAddressData(validateAndFormatPostcode(postcode), false);
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -105,6 +105,7 @@ migration:
 
 testingSupport:
   enableApi: ${TESTING_SUPPORT_ENABLE_API:false}
+  enableCache: ${TESTING_SUPPORT_ENABLE_CACHE:false}
 
 clients:
   cath:

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/config/CacheConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/config/CacheConfigurationTest.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.fact.data.api.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class CacheConfigurationTest {
+
+    @Test
+    void shouldCreateCaffeineCacheManagerWithOsDataCacheRegistered() {
+        CacheConfiguration configuration = new CacheConfiguration();
+
+        CacheManager cacheManager = configuration.cacheManager();
+
+        assertNotNull(cacheManager);
+        assertInstanceOf(CaffeineCacheManager.class, cacheManager);
+
+        Cache osDataCache = cacheManager.getCache(CacheConfiguration.OSDATA_CACHE_NAME);
+        assertNotNull(osDataCache);
+
+        // Basic behavior check to ensure the cache is usable
+        osDataCache.put("key", "value");
+        Cache.ValueWrapper wrapper = osDataCache.get("key");
+        assertNotNull(wrapper);
+        Object value = wrapper.get();
+        assertEquals("value", value);
+    }
+}


### PR DESCRIPTION
### JIRA link ###

n/a

### Change description ###

Add speculative local caching around the postcode lookup calls to try and mitigate 429 errors during the excessive usage triggered by concurrent runs of functional tests across all components.

**Does this PR require manual testing?** (check one with "x")

```
[x] Yes
[ ] No
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
