### PR TITLE
expunge-test-court-audits-on-delete

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/controllers/TestingSupportController.java
@@ -62,7 +62,7 @@ public class TestingSupportController {
         String courtNamePrefix
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(courtService.deleteCourtsByNamePrefix(courtNamePrefix)
+            .body(courtService.deleteCourtsByNamePrefix(courtNamePrefix,true)
                       + " court(s) deleted successfully");
     }
 
@@ -81,7 +81,7 @@ public class TestingSupportController {
         String serviceCentreNamePrefix
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(serviceCentreService.deleteServiceCentresByNamePrefix(serviceCentreNamePrefix)
+            .body(serviceCentreService.deleteServiceCentresByNamePrefix(serviceCentreNamePrefix, true)
                       + " service centre(s) deleted successfully");
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/repositories/AuditRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/repositories/AuditRepository.java
@@ -4,6 +4,7 @@ import uk.gov.hmcts.reform.fact.data.api.entities.Audit;
 import uk.gov.hmcts.reform.fact.data.api.entities.types.AuditSubjectType;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -143,4 +144,11 @@ public interface AuditRepository extends JpaRepository<Audit, UUID> {
     // Housekeeping queries
 
     void deleteAllByCreatedAtBefore(ZonedDateTime createdAtBefore);
+
+    /**
+     * removes all audits where the subject id is in the given list.
+     *
+     * @param auditSubjectIds the list of audit subject ids to delete
+     */
+    void deleteBySubjectIdIn(List<UUID> auditSubjectIds);
 }

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/CourtService.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.fact.data.api.entities.Region;
 import uk.gov.hmcts.reform.fact.data.api.entities.types.NameAndId;
 import uk.gov.hmcts.reform.fact.data.api.errorhandling.exceptions.InvalidParameterCombinationException;
 import uk.gov.hmcts.reform.fact.data.api.errorhandling.exceptions.NotFoundException;
+import uk.gov.hmcts.reform.fact.data.api.repositories.AuditRepository;
 import uk.gov.hmcts.reform.fact.data.api.repositories.CourtDetailsRepository;
 import uk.gov.hmcts.reform.fact.data.api.repositories.CourtRepository;
 
@@ -41,6 +42,7 @@ public class CourtService {
 
     private final CourtRepository courtRepository;
     private final CourtDetailsRepository courtDetailsRepository;
+    private final AuditRepository auditRepository;
     private final RegionService regionService;
     private final CathClient cathClient;
     private final SlackClient slackClient;
@@ -177,7 +179,7 @@ public class CourtService {
      * @return the number of courts removed.
      */
     @Transactional
-    public long deleteCourtsByNamePrefix(String courtNamePrefix) {
+    public long deleteCourtsByNamePrefix(String courtNamePrefix, boolean purgeAudits) {
         List<Court> courtsToDelete = courtRepository.findByNameStartingWithIgnoreCase(courtNamePrefix.trim());
 
         if (courtsToDelete.isEmpty()) {
@@ -185,6 +187,11 @@ public class CourtService {
         }
 
         courtRepository.deleteAllInBatch(courtsToDelete);
+
+        if  (purgeAudits) {
+            auditRepository.deleteBySubjectIdIn(courtsToDelete.stream().map(Court::getId).toList());
+        }
+
         return courtsToDelete.size();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/ServiceCentreService.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/services/ServiceCentreService.java
@@ -3,12 +3,14 @@ package uk.gov.hmcts.reform.fact.data.api.services;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import uk.gov.hmcts.reform.fact.data.api.entities.ServiceArea;
 import uk.gov.hmcts.reform.fact.data.api.entities.ServiceCentre;
 import uk.gov.hmcts.reform.fact.data.api.entities.ServiceCentreDetails;
 import uk.gov.hmcts.reform.fact.data.api.entities.types.CatchmentType;
 import uk.gov.hmcts.reform.fact.data.api.entities.types.NameAndId;
 import uk.gov.hmcts.reform.fact.data.api.errorhandling.exceptions.NotFoundException;
+import uk.gov.hmcts.reform.fact.data.api.repositories.AuditRepository;
 import uk.gov.hmcts.reform.fact.data.api.repositories.ServiceAreaRepository;
 import uk.gov.hmcts.reform.fact.data.api.repositories.ServiceCentreDetailsRepository;
 import uk.gov.hmcts.reform.fact.data.api.repositories.ServiceCentreRepository;
@@ -21,6 +23,7 @@ import java.util.UUID;
 public class ServiceCentreService {
 
     private final ServiceCentreRepository serviceCentreRepository;
+    private final AuditRepository auditRepository;
     private final ServiceCentreDetailsRepository serviceCentreDetailsRepository;
     private final ServiceAreaRepository serviceAreaRepository;
     private final RegionService regionService;
@@ -122,12 +125,16 @@ public class ServiceCentreService {
      * @return The number of service centres deleted.
      */
     @Transactional
-    public long deleteServiceCentresByNamePrefix(String serviceCentreNamePrefix) {
+    public long deleteServiceCentresByNamePrefix(String serviceCentreNamePrefix, boolean purgeAudits) {
         List<ServiceCentre> serviceCentresToDelete =
             serviceCentreRepository.findByNameStartingWithIgnoreCase(serviceCentreNamePrefix.trim());
 
         if (serviceCentresToDelete.isEmpty()) {
             return 0;
+        }
+
+        if  (purgeAudits) {
+            auditRepository.deleteBySubjectIdIn(serviceCentresToDelete.stream().map(ServiceCentre::getId).toList());
         }
 
         serviceCentreRepository.deleteAllInBatch(serviceCentresToDelete);

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/controllers/TestingSupportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/controllers/TestingSupportControllerTest.java
@@ -51,18 +51,19 @@ class TestingSupportControllerTest {
 
     @Test
     void deleteCourtsByNamePrefixReturns200() {
-        when(courtService.deleteCourtsByNamePrefix(COURT_NAME_PREFIX)).thenReturn(3L);
+        when(courtService.deleteCourtsByNamePrefix(COURT_NAME_PREFIX, true)).thenReturn(3L);
 
         ResponseEntity<String> response = testingSupportController.deleteCourtsByNamePrefix(COURT_NAME_PREFIX);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).contains("3 court(s)").doesNotContain(COURT_NAME_PREFIX);
-        verify(courtService).deleteCourtsByNamePrefix(COURT_NAME_PREFIX);
+        verify(courtService).deleteCourtsByNamePrefix(COURT_NAME_PREFIX, true);
     }
 
     @Test
     void deleteCourtsByNamePrefixPropagatesIllegalArgumentExceptionForBlankPrefix() {
-        when(courtService.deleteCourtsByNamePrefix(BLANK_PREFIX)).thenThrow(new IllegalArgumentException("Invalid"));
+        when(courtService.deleteCourtsByNamePrefix(BLANK_PREFIX, true))
+            .thenThrow(new IllegalArgumentException("Invalid"));
 
         assertThrows(IllegalArgumentException.class, () ->
             testingSupportController.deleteCourtsByNamePrefix(BLANK_PREFIX)
@@ -71,14 +72,14 @@ class TestingSupportControllerTest {
 
     @Test
     void deleteServiceCentresByNamePrefixReturns200() {
-        when(serviceCentreService.deleteServiceCentresByNamePrefix(SERVICE_CENTRE_NAME_PREFIX)).thenReturn(2L);
+        when(serviceCentreService.deleteServiceCentresByNamePrefix(SERVICE_CENTRE_NAME_PREFIX, true)).thenReturn(2L);
 
         ResponseEntity<String> response =
             testingSupportController.deleteServiceCentresByNamePrefix(SERVICE_CENTRE_NAME_PREFIX);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).contains("2 service centre(s)").doesNotContain(SERVICE_CENTRE_NAME_PREFIX);
-        verify(serviceCentreService).deleteServiceCentresByNamePrefix(SERVICE_CENTRE_NAME_PREFIX);
+        verify(serviceCentreService).deleteServiceCentresByNamePrefix(SERVICE_CENTRE_NAME_PREFIX, true);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/services/CourtServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/services/CourtServiceTest.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.reform.fact.data.api.entities.Region;
 import uk.gov.hmcts.reform.fact.data.api.entities.types.NameAndId;
 import uk.gov.hmcts.reform.fact.data.api.errorhandling.exceptions.InvalidParameterCombinationException;
 import uk.gov.hmcts.reform.fact.data.api.errorhandling.exceptions.NotFoundException;
+import uk.gov.hmcts.reform.fact.data.api.repositories.AuditRepository;
 import uk.gov.hmcts.reform.fact.data.api.repositories.CourtDetailsRepository;
 import uk.gov.hmcts.reform.fact.data.api.repositories.CourtRepository;
 
@@ -51,6 +52,9 @@ class CourtServiceTest {
 
     @Mock
     private CourtRepository courtRepository;
+
+    @Mock
+    private AuditRepository auditRepository;
 
     @Mock
     private CourtDetailsRepository courtDetailsRepository;
@@ -710,7 +714,7 @@ class CourtServiceTest {
     void deleteCourtsByNamePrefixShouldReturnZeroWhenNoMatchesFound() {
         when(courtRepository.findByNameStartingWithIgnoreCase("Missing")).thenReturn(Collections.emptyList());
 
-        long deleted = courtService.deleteCourtsByNamePrefix("Missing");
+        long deleted = courtService.deleteCourtsByNamePrefix("Missing", true);
 
         assertThat(deleted).isZero();
         verify(courtRepository, never()).deleteAllInBatch(anyList());
@@ -722,7 +726,7 @@ class CourtServiceTest {
         List<Court> courts = List.of(court);
         when(courtRepository.findByNameStartingWithIgnoreCase("Example")).thenReturn(courts);
 
-        long deleted = courtService.deleteCourtsByNamePrefix("  Example ");
+        long deleted = courtService.deleteCourtsByNamePrefix("  Example ",true);
 
         assertThat(deleted).isEqualTo(1);
         verify(courtRepository).findByNameStartingWithIgnoreCase("Example");

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/services/ServiceCentreServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/services/ServiceCentreServiceTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.fact.data.api.entities.ServiceCentreDetails;
 import uk.gov.hmcts.reform.fact.data.api.entities.types.CatchmentType;
 import uk.gov.hmcts.reform.fact.data.api.entities.types.NameAndId;
 import uk.gov.hmcts.reform.fact.data.api.errorhandling.exceptions.NotFoundException;
+import uk.gov.hmcts.reform.fact.data.api.repositories.AuditRepository;
 import uk.gov.hmcts.reform.fact.data.api.repositories.ServiceAreaRepository;
 import uk.gov.hmcts.reform.fact.data.api.repositories.ServiceCentreDetailsRepository;
 import uk.gov.hmcts.reform.fact.data.api.repositories.ServiceCentreRepository;
@@ -32,6 +33,9 @@ class ServiceCentreServiceTest {
 
     @Mock
     private ServiceCentreRepository serviceCentreRepository;
+
+    @Mock
+    private AuditRepository auditRepository;
 
     @Mock
     private ServiceCentreDetailsRepository serviceCentreDetailsRepository;
@@ -207,7 +211,7 @@ class ServiceCentreServiceTest {
         List<ServiceCentre> serviceCentres = List.of(first, second);
         when(serviceCentreRepository.findByNameStartingWithIgnoreCase("SC Delete")).thenReturn(serviceCentres);
 
-        long deleted = serviceCentreService.deleteServiceCentresByNamePrefix("SC Delete");
+        long deleted = serviceCentreService.deleteServiceCentresByNamePrefix("SC Delete", true);
 
         assertThat(deleted).isEqualTo(2);
         verify(serviceCentreRepository).deleteAllInBatch(serviceCentres);


### PR DESCRIPTION
### JIRA link ###

FACT-2658

### Change description ###

Add audit purge option to deleteByPrefix methods for both service centres and courts

**Does this PR require manual testing?** (check one with "x")

```
[ ] Yes
[x] No
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
