### PR TITLE
FACT-2712

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/dto/AllLocation.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/dto/AllLocation.java
@@ -38,6 +38,7 @@ public class AllLocation {
             .slug(court.getSlug())
             .open(court.getOpen())
             .warningNotice(court.getWarningNotice())
+            .warningNoticeCy(court.getWarningNoticeCy())
             .createdAt(court.getCreatedAt())
             .lastUpdatedAt(court.getLastUpdatedAt())
             .locationType("COURT")

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/model/CourtDto.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/model/CourtDto.java
@@ -16,6 +16,10 @@ public class CourtDto {
     private String name;
     private String slug;
     private Boolean open;
+    @JsonProperty("warning_notice")
+    private String warningNotice;
+    @JsonProperty("warning_notice_cy")
+    private String warningNoticeCy;
     @JsonProperty("region_id")
     private Integer regionId;
     @JsonProperty("court_service_areas")

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/model/MigrationResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/model/MigrationResult.java
@@ -1,12 +1,10 @@
 package uk.gov.hmcts.reform.fact.data.api.migration.model;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 public class MigrationResult {
     private int courtsMigrated;
     private int serviceCentresMigrated;
@@ -18,4 +16,5 @@ public class MigrationResult {
     private int courtDxCodesMigrated;
     private int courtFaxMigrated;
     private int serviceCentreAreasOfLawMigrated;
+    private int warningNoticesMigrated;
 }

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/service/CourtMigrationHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/service/CourtMigrationHelper.java
@@ -134,6 +134,16 @@ class CourtMigrationHelper {
                 .name(courtName)
                 .slug(dto.getSlug())
                 .open(dto.getOpen())
+                .warningNotice(WarningNoticeSanitiser.sanitise(
+                    dto.getWarningNotice(),
+                    dto.getSlug(),
+                    "English"
+                ))
+                .warningNoticeCy(WarningNoticeSanitiser.sanitise(
+                    dto.getWarningNoticeCy(),
+                    dto.getSlug(),
+                    "Welsh"
+                ))
                 .regionId(regionId.get())
                 .build();
 
@@ -143,6 +153,10 @@ class CourtMigrationHelper {
             } catch (ConstraintViolationException ex) {
                 LOG.error("Validation failed while migrating court '{}': {}", dto.getName(), ex.getMessage());
                 throw ex;
+            }
+            if (StringUtils.isNotBlank(savedCourt.getWarningNotice())
+                || StringUtils.isNotBlank(savedCourt.getWarningNoticeCy())) {
+                context.warningNoticesMigrated++;
             }
             UUID courtId = savedCourt.getId();
             persistCourtAreasOfLaw(dto.getCourtAreasOfLaw(), courtId, context);

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/service/MigrationContext.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/service/MigrationContext.java
@@ -20,4 +20,5 @@ class MigrationContext {
     int courtDxCodesMigrated;
     int courtFaxMigrated;
     int serviceCentreAreasOfLawMigrated;
+    int warningNoticesMigrated;
 }

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/service/MigrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/service/MigrationService.java
@@ -109,7 +109,7 @@ public class MigrationService {
             MigrationSummary summary = transactionTemplate.execute(status -> persistExport(exportResponse));
             markMigrationStatus(MigrationStatus.SUCCESS);
             return summary;
-        } catch (RuntimeException ex) {
+        } catch (RuntimeException | LinkageError ex) {
             markMigrationStatus(MigrationStatus.FAILED);
             throw ex;
         }
@@ -122,18 +122,18 @@ public class MigrationService {
         int serviceCentresMigrated =
             serviceCentreMigrationHelper.migrateServiceCentres(exportResponse.getCourts(), context);
 
-        MigrationResult result = new MigrationResult(
-            courtsMigrated,
-            serviceCentresMigrated,
-            context.getCourtAreasOfLawMigrated(),
-            context.getCourtLocalAuthoritiesMigrated(),
-            context.getCourtSinglePointsOfEntryMigrated(),
-            context.getCourtProfessionalInformationMigrated(),
-            context.getCourtCodesMigrated(),
-            context.getCourtDxCodesMigrated(),
-            context.getCourtFaxMigrated(),
-            context.getServiceCentreAreasOfLawMigrated()
-        );
+        MigrationResult result = new MigrationResult();
+        result.setCourtsMigrated(courtsMigrated);
+        result.setServiceCentresMigrated(serviceCentresMigrated);
+        result.setCourtAreasOfLawMigrated(context.getCourtAreasOfLawMigrated());
+        result.setCourtLocalAuthoritiesMigrated(context.getCourtLocalAuthoritiesMigrated());
+        result.setCourtSinglePointsOfEntryMigrated(context.getCourtSinglePointsOfEntryMigrated());
+        result.setCourtProfessionalInformationMigrated(context.getCourtProfessionalInformationMigrated());
+        result.setCourtCodesMigrated(context.getCourtCodesMigrated());
+        result.setCourtDxCodesMigrated(context.getCourtDxCodesMigrated());
+        result.setCourtFaxMigrated(context.getCourtFaxMigrated());
+        result.setServiceCentreAreasOfLawMigrated(context.getServiceCentreAreasOfLawMigrated());
+        result.setWarningNoticesMigrated(context.getWarningNoticesMigrated());
 
         return new MigrationSummary(result);
     }

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/service/ServiceCentreMigrationHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/service/ServiceCentreMigrationHelper.java
@@ -71,6 +71,16 @@ class ServiceCentreMigrationHelper {
                 .name(serviceCentreName)
                 .slug(dto.getSlug())
                 .open(Boolean.FALSE)
+                .warningNotice(WarningNoticeSanitiser.sanitise(
+                    dto.getWarningNotice(),
+                    dto.getSlug(),
+                    "English"
+                ))
+                .warningNoticeCy(WarningNoticeSanitiser.sanitise(
+                    dto.getWarningNoticeCy(),
+                    dto.getSlug(),
+                    "Welsh"
+                ))
                 .serviceAreaIds(serviceAreaSelection.serviceAreaIds())
                 .regionId(mapRegionId(dto, context))
                 .catchmentType(serviceAreaSelection.catchmentType().orElse(null))
@@ -82,6 +92,10 @@ class ServiceCentreMigrationHelper {
             } catch (ConstraintViolationException ex) {
                 LOG.error("Validation failed while migrating service centre '{}': {}", dto.getName(), ex.getMessage());
                 throw ex;
+            }
+            if (StringUtils.isNotBlank(savedServiceCentre.getWarningNotice())
+                || StringUtils.isNotBlank(savedServiceCentre.getWarningNoticeCy())) {
+                context.warningNoticesMigrated++;
             }
 
             UUID serviceCentreId = savedServiceCentre.getId();

--- a/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/service/WarningNoticeSanitiser.java
+++ b/src/main/java/uk/gov/hmcts/reform/fact/data/api/migration/service/WarningNoticeSanitiser.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.fact.data.api.migration.service;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.util.HtmlUtils;
+
+final class WarningNoticeSanitiser {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WarningNoticeSanitiser.class);
+    private static final Pattern HTML_TAG_PATTERN = Pattern.compile("<[^>]*>");
+    private static final Pattern WHITESPACE_BEFORE_PUNCTUATION = Pattern.compile("\\s+([.,!?:;])");
+
+    private WarningNoticeSanitiser() {
+    }
+
+    static String sanitise(String value, String courtSlug, String language) {
+        if (StringUtils.isBlank(value)) {
+            return null;
+        }
+
+        String sanitised = HtmlUtils.htmlUnescape(value);
+        sanitised = HTML_TAG_PATTERN.matcher(sanitised).replaceAll(" ")
+            .replace('‘', '\'')
+            .replace('’', '\'')
+            .replace('“', '"')
+            .replace('”', '"')
+            .replace("–", "-")
+            .replace("—", "-")
+            .replace("…", "...");
+        sanitised = StringUtils.normalizeSpace(sanitised);
+        sanitised = WHITESPACE_BEFORE_PUNCTUATION.matcher(sanitised).replaceAll("$1");
+
+        if (!Objects.equals(value, sanitised)) {
+            LOG.info("Sanitised {} warning notice for legacy court '{}'", language, courtSlug);
+        }
+        return StringUtils.defaultIfBlank(sanitised, null);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/dto/AllLocationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/dto/AllLocationTest.java
@@ -26,6 +26,7 @@ class AllLocationTest {
             .slug("test-court")
             .open(true)
             .warningNotice("Court warning")
+            .warningNoticeCy("Rhybudd llys")
             .createdAt(CREATED_AT)
             .lastUpdatedAt(LAST_UPDATED_AT)
             .regionId(REGION_ID)
@@ -40,6 +41,7 @@ class AllLocationTest {
         assertThat(result.getSlug()).isEqualTo("test-court");
         assertThat(result.getOpen()).isTrue();
         assertThat(result.getWarningNotice()).isEqualTo("Court warning");
+        assertThat(result.getWarningNoticeCy()).isEqualTo("Rhybudd llys");
         assertThat(result.getCreatedAt()).isEqualTo(CREATED_AT);
         assertThat(result.getLastUpdatedAt()).isEqualTo(LAST_UPDATED_AT);
         assertThat(result.getLocationType()).isEqualTo("COURT");

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/model/CourtDtoTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/model/CourtDtoTest.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.fact.data.api.migration.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class CourtDtoTest {
+
+    @Test
+    void shouldDeserialiseWarningNoticesFromLegacyMigrationContract() {
+        ObjectMapper mapper = JsonMapper.builder().build();
+
+        CourtDto court = mapper.readValue(
+            """
+                {
+                  "id": 1,
+                  "slug": "example-court",
+                  "warning_notice": "<strong>Urgent &amp; important</strong>",
+                  "warning_notice_cy": "Rhybudd brys"
+                }
+                """,
+            CourtDto.class
+        );
+
+        assertThat(court.getWarningNotice()).isEqualTo("<strong>Urgent &amp; important</strong>");
+        assertThat(court.getWarningNoticeCy()).isEqualTo("Rhybudd brys");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/model/MigrationResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/model/MigrationResponseTest.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.fact.data.api.migration.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+class MigrationResponseTest {
+
+    @Test
+    void shouldIncludeWarningNoticeCountInResponseJson() {
+        MigrationResult result = new MigrationResult();
+        result.setCourtsMigrated(1);
+        result.setServiceCentresMigrated(1);
+        result.setWarningNoticesMigrated(2);
+
+        String json = JsonMapper.builder().build().writeValueAsString(
+            new MigrationResponse("Migration completed successfully", result)
+        );
+
+        assertThat(json).contains("\"warningNoticesMigrated\":2");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/service/CourtMigrationHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/service/CourtMigrationHelperTest.java
@@ -114,6 +114,7 @@ class CourtMigrationHelperTest {
         assertThat(context.getCourtAreasOfLawMigrated()).isEqualTo(1);
         assertThat(context.getCourtLocalAuthoritiesMigrated()).isEqualTo(1);
         assertThat(context.getCourtSinglePointsOfEntryMigrated()).isEqualTo(1);
+        assertThat(context.getWarningNoticesMigrated()).isZero();
     }
 
     @Test
@@ -181,6 +182,34 @@ class CourtMigrationHelperTest {
         verify(courtService).createCourt(captor.capture());
         assertThat(captor.getValue().getName())
             .isEqualTo("Enforcement (Crime) Contact Centre - Wales South West & London");
+    }
+
+    @Test
+    void shouldSanitiseAndPersistWarningNotices() {
+        context.getRegionIds().put(1, UUID.randomUUID());
+        when(courtService.createCourt(any(Court.class))).thenAnswer(invocation -> {
+            Court court = invocation.getArgument(0);
+            court.setId(UUID.randomUUID());
+            return court;
+        });
+
+        CourtDto dto = new CourtDto();
+        dto.setId(706L);
+        dto.setName("Warning Notice Court");
+        dto.setSlug("warning-notice-court");
+        dto.setOpen(true);
+        dto.setWarningNotice("<strong>Urgent &amp; important</strong>");
+        dto.setWarningNoticeCy("<strong>Rhybudd:</strong> mae’r llys ar gau.");
+        dto.setRegionId(1);
+        dto.setIsServiceCentre(false);
+
+        helper.migrateCourts(List.of(dto), context);
+
+        ArgumentCaptor<Court> captor = ArgumentCaptor.forClass(Court.class);
+        verify(courtService).createCourt(captor.capture());
+        assertThat(captor.getValue().getWarningNotice()).isEqualTo("Urgent & important");
+        assertThat(captor.getValue().getWarningNoticeCy()).isEqualTo("Rhybudd: mae'r llys ar gau.");
+        assertThat(context.getWarningNoticesMigrated()).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/service/MigrationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/service/MigrationServiceTest.java
@@ -77,6 +77,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -253,10 +254,26 @@ class MigrationServiceTest {
     }
 
     @Test
+    void shouldMarkMigrationFailedWhenLinkageErrorOccurs() {
+        when(legacyFactClient.fetchExport()).thenReturn(new LegacyExportResponse());
+        doThrow(new NoSuchMethodError("stale runtime class")).when(transactionTemplate).execute(any());
+
+        assertThrows(NoSuchMethodError.class, () -> migrationService.migrate());
+
+        ArgumentCaptor<MigrationAudit> auditCaptor = ArgumentCaptor.forClass(MigrationAudit.class);
+        verify(migrationAuditRepository, atLeastOnce()).save(auditCaptor.capture());
+        assertThat(auditCaptor.getAllValues().get(0).getStatus()).isEqualTo(MigrationStatus.IN_PROGRESS);
+        assertThat(auditCaptor.getAllValues().get(auditCaptor.getAllValues().size() - 1).getStatus())
+            .isEqualTo(MigrationStatus.FAILED);
+    }
+
+    @Test
     void shouldPersistLegacyDataAndReturnSummary() {
+        CourtDto court = courtDto();
+        court.setWarningNotice("Temporary warning");
 
         LegacyExportResponse response = new LegacyExportResponse(
-            List.of(courtDto()),
+            List.of(court),
             List.of(new LocalAuthorityTypeDto(1, "Local Authority")),
             List.of(serviceAreaDto()),
             List.of(serviceDto()),
@@ -287,6 +304,7 @@ class MigrationServiceTest {
         assertThat(result.getCourtDxCodesMigrated()).isEqualTo(1);
         assertThat(result.getCourtFaxMigrated()).isEqualTo(1);
         assertThat(result.getServiceCentreAreasOfLawMigrated()).isZero();
+        assertThat(result.getWarningNoticesMigrated()).isEqualTo(1);
 
         verify(legacyServiceRepository).save(any(LegacyService.class));
         verify(courtAreasOfLawRepository).save(any());
@@ -334,6 +352,8 @@ class MigrationServiceTest {
             "Service Centre Court",
             "service-centre-court",
             true,
+            "Service centre warning",
+            "Rhybudd canolfan wasanaeth",
             null,
             List.of(new CourtServiceAreaDto(1, CatchmentType.NATIONAL.name(), List.of(1))),
             List.of(new CourtLocalAuthorityDto(1, 1, List.of(1))),
@@ -368,6 +388,7 @@ class MigrationServiceTest {
         assertThat(summary.getResult().getCourtsMigrated()).isZero();
         assertThat(summary.getResult().getServiceCentresMigrated()).isEqualTo(1);
         assertThat(summary.getResult().getServiceCentreAreasOfLawMigrated()).isEqualTo(1);
+        assertThat(summary.getResult().getWarningNoticesMigrated()).isEqualTo(1);
         verify(courtService, never()).createCourt(any(Court.class));
         verify(serviceCentreRepository).save(any(ServiceCentre.class));
         verify(serviceCentreAreasOfLawRepository).save(any());
@@ -379,6 +400,8 @@ class MigrationServiceTest {
             "Example Court",
             "example-court",
             true,
+            null,
+            null,
             1,
             List.of(new CourtServiceAreaDto(1, CatchmentType.LOCAL.name(), List.of(1))),
             List.of(new CourtLocalAuthorityDto(1, 1, List.of(1))),
@@ -428,6 +451,8 @@ class MigrationServiceTest {
             "Example Court",
             "example-court",
             true,
+            null,
+            null,
             1,
             List.of(new CourtServiceAreaDto(1, CatchmentType.LOCAL.name(), List.of(1))),
             List.of(new CourtLocalAuthorityDto(1, 1, List.of(1))),

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/service/PhotoMigrationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/service/PhotoMigrationServiceTest.java
@@ -141,6 +141,8 @@ class PhotoMigrationServiceTest {
             null,
             null,
             null,
+            null,
+            null,
             new CourtPhotoDto(photoPath),
             null
         );

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/service/ServiceCentreMigrationHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/service/ServiceCentreMigrationHelperTest.java
@@ -76,6 +76,11 @@ class ServiceCentreMigrationHelperTest {
         assertThat(serviceCentreCaptor.getValue().getName()).isEqualTo("Legacy Service Centre");
         assertThat(serviceCentreCaptor.getValue().getSlug()).isEqualTo("legacy-service-centre");
         assertThat(serviceCentreCaptor.getValue().getOpen()).isFalse();
+        assertThat(serviceCentreCaptor.getValue().getWarningNotice())
+            .isEqualTo("Urgent & important");
+        assertThat(serviceCentreCaptor.getValue().getWarningNoticeCy())
+            .isEqualTo("Rhybudd: mae'r ganolfan ar gau.");
+        assertThat(context.getWarningNoticesMigrated()).isEqualTo(1);
         assertThat(serviceCentreCaptor.getValue().getServiceAreaIds()).containsExactly(nationalServiceAreaId);
         assertThat(serviceCentreCaptor.getValue().getRegionId()).isEqualTo(regionId);
         assertThat(serviceCentreCaptor.getValue().getCatchmentType()).isEqualTo(CatchmentType.NATIONAL);
@@ -407,6 +412,8 @@ class ServiceCentreMigrationHelperTest {
         serviceCentreDto.setName("Legacy Service Centre");
         serviceCentreDto.setSlug("legacy-service-centre");
         serviceCentreDto.setOpen(true);
+        serviceCentreDto.setWarningNotice("<strong>Urgent &amp; important</strong>");
+        serviceCentreDto.setWarningNoticeCy("<strong>Rhybudd:</strong> mae’r ganolfan ar gau.");
         serviceCentreDto.setIsServiceCentre(true);
         serviceCentreDto.setRegionId(5);
         serviceCentreDto.setCourtServiceAreas(List.of(

--- a/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/service/WarningNoticeSanitiserTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/fact/data/api/migration/service/WarningNoticeSanitiserTest.java
@@ -1,0 +1,81 @@
+package uk.gov.hmcts.reform.fact.data.api.migration.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.fact.data.api.entities.Court;
+import uk.gov.hmcts.reform.fact.data.api.entities.ServiceCentre;
+
+class WarningNoticeSanitiserTest {
+
+    @Test
+    void shouldConvertLegacyHtmlAndEntitiesToPlainText() {
+        String value = """
+            For queries, email <a href="mailto:notices&#64;example.com">
+            notices&#64;example.com</a>.
+            """;
+
+        String result = WarningNoticeSanitiser.sanitise(value, "example-court", "English");
+
+        assertThat(result).isEqualTo(
+            "For queries, email notices@example.com."
+        );
+    }
+
+    @Test
+    void shouldNormaliseWhitespaceAndTypographicPunctuation() {
+        String value = """
+            <strong>The Chair Lift is Out of Order.</strong>\r
+            Cases will move to Magistrates’ Court – please don’t attend…
+            """;
+
+        String result = WarningNoticeSanitiser.sanitise(value, "example-court", "English");
+
+        assertThat(result).isEqualTo(
+            "The Chair Lift is Out of Order. Cases will move to Magistrates' Court - please don't attend..."
+        );
+    }
+
+    @Test
+    void shouldPreserveWelshLetters() {
+        String result = WarningNoticeSanitiser.sanitise(
+            "<strong>Rhybudd:</strong> Mae’r llys yng Nghaerdydd wedi cau dros dro.",
+            "example-court",
+            "Welsh"
+        );
+
+        assertThat(result).isEqualTo("Rhybudd: Mae'r llys yng Nghaerdydd wedi cau dros dro.");
+    }
+
+    @Test
+    void shouldProduceValuesAcceptedByTargetEntityConstraints() {
+        String english = WarningNoticeSanitiser.sanitise(
+            "<p>Don’t attend – email notices&#64;example.com…</p>",
+            "example-court",
+            "English"
+        );
+        String welsh = WarningNoticeSanitiser.sanitise(
+            "<p>Peidiwch â dod – e-bostiwch notices&#64;example.com…</p>",
+            "example-court",
+            "Welsh"
+        );
+
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+
+            assertThat(validator.validateValue(Court.class, "warningNotice", english)).isEmpty();
+            assertThat(validator.validateValue(Court.class, "warningNoticeCy", welsh)).isEmpty();
+            assertThat(validator.validateValue(ServiceCentre.class, "warningNotice", english)).isEmpty();
+            assertThat(validator.validateValue(ServiceCentre.class, "warningNoticeCy", welsh)).isEmpty();
+        }
+    }
+
+    @Test
+    void shouldMapBlankNoticeToNull() {
+        assertThat(WarningNoticeSanitiser.sanitise("  ", "example-court", "English")).isNull();
+        assertThat(WarningNoticeSanitiser.sanitise(null, "example-court", "Welsh")).isNull();
+    }
+}


### PR DESCRIPTION
Adds migration support for legacy English and Welsh warning notices for courts and service centres, including sanitisation and migration result counts. Updates tests to cover deserialisation, persistence, validation and response output using synthetic data only.